### PR TITLE
Remove wp-security-collection from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     "koodimonni-language/core-fi": "*",
 
     "devgeniem/wp-safe-fast-and-clean-collection": ">=1.0",
-    "devgeniem/wp-security-collection": ">=1.0",
 
     "devgeniem/better-wp-db-error": ">=0.1",
     "devgeniem/wp-noindex-testing-staging-robots": "^1.0",


### PR DESCRIPTION
Remove the dependency, because it is a meta package that requires two dependencies that are already required in the project composer.json and in the wp-safe-fast-and-clean-collection -meta package.