### PR TITLE
Search engine visibility is controlled with an env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Added a default `WP_READ_ONLY_OPTION` constant and set it to replace the `blog_public` option.
 
 ## [20171005] - 2017-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 
-- Added a default `WP_READ_ONLY_OPTION` constant and set it to replace the `blog_public` option.
+- Added a default `WP_READONLY_OPTIONS` constant and set it to replace the `blog_public` option.
 
 ## [20171005] - 2017-10-05
 

--- a/config/application.php
+++ b/config/application.php
@@ -186,6 +186,15 @@ if ( file_exists( $env_config ) ) {
 }
 
 /**
+ * Define read only options to override WordPress database options.
+ */
+define( 'WP_READONLY_OPTIONS', [
+    // 1 : I would like my blog to be visible to everyone, including search engines.
+    // 0 : I would like to block search engines, but allow normal visitors.
+    'blog_public' => env( 'WP_BLOG_PUBLIC' ) ?: 0,
+] );
+
+/**
  * Bootstrap WordPress
  */
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
The WordPress option `blog_public` is now controlled with a read only option defined in `application.php`.