### PR TITLE
Check for constant PLL_LINGOTEK_AD

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -168,8 +168,10 @@ if ( defined( 'WP_CLI' ) and WP_CLI and ! defined( 'PLL_ADMIN' ) ) {
     define( 'PLL_ADMIN', true );
 }
 
-// Disable Lingotek notice and menu item from Polylang
-define( 'PLL_LINGOTEK_AD', false );
+// Disable Lingotek notice and menu item from Polylang free version.
+if ( ! defined( 'PLL_LINGOTEK_AD' ) )  { 
+    define( 'PLL_LINGOTEK_AD', false );
+}
 
 /**
  * Define memory limit so that wp-cli can use more memory than the default 40M

--- a/config/application.php
+++ b/config/application.php
@@ -177,7 +177,6 @@ function hide_polylang_ads() {
     }
 }
 
-
 /**
  * Define memory limit so that wp-cli can use more memory than the default 40M
  */

--- a/config/application.php
+++ b/config/application.php
@@ -168,10 +168,15 @@ if ( defined( 'WP_CLI' ) and WP_CLI and ! defined( 'PLL_ADMIN' ) ) {
     define( 'PLL_ADMIN', true );
 }
 
+// This needs to run after plugins are loaded.
+add_action( 'plugins_loaded', 'hide_polylang_ads' );
 // Disable Lingotek notice and menu item from Polylang free version.
-if ( ! defined( 'PLL_LINGOTEK_AD' ) )  { 
-    define( 'PLL_LINGOTEK_AD', false );
+function hide_polylang_ads() {
+    if ( ! defined( 'PLL_LINGOTEK_AD' ) )  { 
+        define( 'PLL_LINGOTEK_AD', false );
+    }
 }
+
 
 /**
  * Define memory limit so that wp-cli can use more memory than the default 40M


### PR DESCRIPTION
Check if constant PLL_LINGOTEK_AD is already defined. This removes Lingotek notice and menu item from Polylang free version but is set to false in the premium version. Check prevents error when used with Polylang Pro.