### PR TITLE
Remove PLL_LINGOTEK_AD

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -168,9 +168,6 @@ if ( defined( 'WP_CLI' ) and WP_CLI and ! defined( 'PLL_ADMIN' ) ) {
     define( 'PLL_ADMIN', true );
 }
 
-// Disable Lingotek notice and menu item from Polylang
-define( 'PLL_LINGOTEK_AD', false );
-
 /**
  * Define memory limit so that wp-cli can use more memory than the default 40M
  */


### PR DESCRIPTION
Remove PLL_LINGOTEK_AD, causes problems with pro version of polylang.
Solves #52, after [this](https://github.com/devgeniem/wp-safe-fast-and-clean-collection/pull/3) PR is merged.