### PR TITLE
Disable 5min http request cache

### DIFF
--- a/nginx/server/proxy-settings.conf
+++ b/nginx/server/proxy-settings.conf
@@ -29,7 +29,7 @@ proxy_buffering         off;
 proxy_intercept_errors  on;
 
 # Enable client-side caching.
-expires 5m;
+# expires 5m;
 
 # Allow pagespeed to optimize images from this cache
 pagespeed AllowVaryOn Auto;


### PR DESCRIPTION
Comment the expires 5m line out so that the cache is not set. This fixes admin caching problems.