### PR TITLE
Add a global xdebug volume for xdebug profiling data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+### Changed
+- Xdebug profiling data is stored in a global volume and not synced to the local machine.
+
+## [0.6.4] - 2018-09-28
 - Add WP_BLOG_PUBLIC:0 to configuration files
+
+## [0.6.3] - 2018-06-04
 - Removed Flynn stuff from Dockerfile
 - Added cron runner priviledges to Dockerfile
 - Added optional beta image commented out to Dockerfile

--- a/docker-compose-ubuntu.yml
+++ b/docker-compose-ubuntu.yml
@@ -16,8 +16,8 @@ services:
       # Sync files into this path with sync container
       - .:/var/www/project
 
-      # Use volume for xdebug trace and profiling so we can use analysing in other containers
-      - /tmp/xdebug
+      # Uncomment to enable Xdebug profiling
+      # - xdebug:/tmp/xdebug
 
       # In production uploads will be in /data/uploads/
       # This way let the container see them like in production
@@ -139,12 +139,17 @@ services:
   # For Example: use yoursite.test/?XDEBUG_PROFILE to profile the front page
   ##
 
+    # Uncomment to enable Xdebug profiling
   # webgrind:
   #   image: devgeniem/webgrind
   #   ports:
   #     - 80
   #   volumes:
-  #     - .:/var/www/project
+  #     - xdebug:/tmp/xdebug
   #   environment:
   #     VIRTUAL_HOST: webgrind.wordpress.test
   #   network_mode: bridge
+
+# Uncomment to enable Xdebug profiling
+# volumes:
+#   xdebug:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,8 @@ services:
       # Exclude theme's node_modules from the sync for performance reasons
       - /var/www/project/web/app/themes/THEMENAME/node_modules/
 
-      # Use volume for xdebug trace and profiling so we can use analysing in other containers
-      - /tmp/xdebug
+      # Uncomment to enable Xdebug profiling
+      # - xdebug:/tmp/xdebug
 
       # In production uploads will be in /data/uploads/
       # This way let the container see them like in production
@@ -153,14 +153,17 @@ services:
   # For Example: use yoursite.test/?XDEBUG_PROFILE to profile the front page
   ##
 
+  # Uncomment to enable Xdebug profiling
   # webgrind:
   #   image: devgeniem/webgrind
   #   ports:
   #     - 80
   #   volumes:
-  #     - .:/var/www/project
-  #     - /var/www/project/web/app/themes/THEMENAME/node_modules/
+  #     - xdebug:/tmp/xdebug
   #   environment:
   #     VIRTUAL_HOST: webgrind.wordpress.test
   #   network_mode: bridge
 
+# Uncomment to enable Xdebug profiling
+# volumes:
+#   xdebug:


### PR DESCRIPTION
### Changed
- Xdebug profiling data is stored in a global volume and not synced to the local machine.