### PR TITLE
Run cron basic authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Added nginx helper
 - Added google api key to docker-compose
 
+## [0.6.3] - 2018-10-22
+- Changed run-cron.sh to use basic authentication if envs BASIC_AUTH_USER and BASIC_AUTH_PASSWORD has been setted.
+
 ## [0.6.2] - 2018-06-04
 - Changed pagespeed config: InPlaceResourceOptimization on; -> off
 

--- a/scripts/run-cron.sh
+++ b/scripts/run-cron.sh
@@ -1,2 +1,8 @@
 #!/bin/bash
+
+# If BASIC_AUTH_PASSWORD is set use basic authentication on curl.
+if [[ -z "${BASIC_AUTH_USER}" ]] && [[ -z "${BASIC_AUTH_PASSWORD}" ]]; then
+curl -u $BASIC_AUTH_USER:$BASIC_AUTH_PASSWORD $CRON_URL > /dev/null 2>&1
+else
 curl $CRON_URL > /dev/null 2>&1
+fi

--- a/scripts/run-cron.sh
+++ b/scripts/run-cron.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # If BASIC_AUTH_PASSWORD is set use basic authentication on curl.
-if [[ -z "${BASIC_AUTH_USER}" ]] && [[ -z "${BASIC_AUTH_PASSWORD}" ]]; then
+if [[ "${BASIC_AUTH_USER}" ]] && [[ "${BASIC_AUTH_PASSWORD}" ]]; then
 curl -u $BASIC_AUTH_USER:$BASIC_AUTH_PASSWORD $CRON_URL > /dev/null 2>&1
 else
 curl $CRON_URL > /dev/null 2>&1


### PR DESCRIPTION
## [0.6.3] - 2018-10-22
- Changed run-cron.sh to use basic authentication if envs BASIC_AUTH_USER and BASIC_AUTH_PASSWORD has been setted.