### PR TITLE
Set max ttl for object cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.8.0] - 2018-11-12
+
+### Added
+
+- `WP_REDIS_MAXTTL` constant set to 30 days for production environment and to 4 hours for staging environment.
+
+### Changed
+
+- `WP_REDIS_MAXTTL` constant set to 60 seconds for development environment.
+
 ## [0.7.0] - 2018-10-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.7.0] - 2018-10-29
+
 ### Changed
 - Xdebug profiling data is stored in a global volume and not synced to the local machine.
 

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -16,9 +16,9 @@ define( 'FORCE_SSL_ADMIN', true );
 
 /**
  * Use object cache so that we don't have parity problems with production
- * but only cache values for 1 second so that developers can be more productive
+ * but only cache values for 60 seconds so that developers can be more productive
  */
-define( 'WP_REDIS_MAXTTL', 1 );
+define( 'WP_REDIS_MAXTTL', 60 );
 
 /**
  * Use elasticsearch from local linked docker container

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -15,3 +15,8 @@ define( 'DISALLOW_FILE_MODS', true );
  * Always use HTTPS in admin
  */
 define( 'FORCE_SSL_ADMIN', true );
+
+/**
+ * Expiration time for WP object cache in seconds.
+ */
+define( 'WP_REDIS_MAXTTL', 60 * 60 * 24 * 30 );

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -19,4 +19,4 @@ define( 'FORCE_SSL_ADMIN', true );
 /**
  * Expiration time for WP object cache in seconds.
  */
-define( 'WP_REDIS_MAXTTL', 60 * 60 * 24 * 4 );
+define( 'WP_REDIS_MAXTTL', 60 * 60 * 4 );

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -15,3 +15,8 @@ define( 'DISALLOW_FILE_MODS', true );
  * Always use HTTPS in admin
  */
 define( 'FORCE_SSL_ADMIN', true );
+
+/**
+ * Expiration time for WP object cache in seconds.
+ */
+define( 'WP_REDIS_MAXTTL', 60 * 60 * 24 * 4 );


### PR DESCRIPTION
### Added

- `WP_REDIS_MAXTTL` constant set to 30 days for production environment and to 4 hours for staging environment.

### Changed

- `WP_REDIS_MAXTTL` constant set to 60 seconds for development environment.
