### PR TITLE
Fix the author url deny rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.8.2] - 2019-02-13
+
+### Fixed
+- Make the deny rule for author urls to be more exact to prevent mismatching locations.
+
 ## [0.8.1] - 2018-11-18
 
 ### Added

--- a/nginx/server/security.conf
+++ b/nginx/server/security.conf
@@ -14,8 +14,11 @@
 location = /xmlrpc.php { access_log $blocked_log blocked; deny all; }
 location = /wp/xmlrpc.php { access_log $blocked_log blocked; deny all; }
 
-#Disable author to block username fishing
-location ~ /author { access_log $blocked_log blocked; deny all; }
+##
+# Block username fishing by disabling urls starting with '/author/'.
+# Remove this line to enable author pages.
+##
+location /author/ { access_log $blocked_log blocked; deny all; }
 
 # Allows certificate verification
 location = /.well-known/pki-validation/gsdv.txt { allow all; }


### PR DESCRIPTION
### Fixed
- Make the deny rule for author urls to be more exact to prevent mismatching locations.