### PR TITLE
Add devgeniem/wp-disable-redis-object-cache-dropin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.9.0] - 2019-05-20
+
 ### Added
 - Database dump file extensions to .dockerignore to prevent them from bloating the images.
+- Add `devgeniem/wp-disable-redis-object-cache-dropin` to disable Redis object caching on WP preview.
 
 ### Changed
 - Disabled basic auth for uploads directory even if it was on for the rest of the project.

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
     "devgeniem/wp-redis-group-cache": "^2.0",
     "devgeniem/wp-stateless-bucket-link-filter": "^1.0",
     "devgeniem/kontena-cluster-configs": "^1.3",
-    "devgeniem/wp-cron-runner": "*"
+    "devgeniem/wp-cron-runner": "*",
+    "devgeniem/wp-disable-redis-object-cache-dropin": "^1.0"
   },
   "require-dev": {
     "rarst/wps": ">=1.0.0",


### PR DESCRIPTION
Add `devgeniem/wp-disable-redis-object-cache-dropin` to disable Redis object caching on WP preview.