### PR TITLE
disallow long array syntax

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -82,6 +82,9 @@
   <!-- This might be problematic when using wp actions/filters -->
   <rule ref="Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeComma"/>
 
+  <!-- Disallow array() in favour of [] -->
+  <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+
   <!--
     Ending tags '?>' can be really painful to debug.
     Just disallow them in the end of the file


### PR DESCRIPTION
Either this or:
```
<!-- Disallow [] in favour of array() -->
<rule ref="Generic.Arrays.DisallowShortArraySyntax">
```
should be added to the php linting rules to make the code more consistent, in this case i added the rule to disallow the long syntax but this is purely a personal preference and can be switched to the other one.