### PR TITLE
Cloud build yaml fixes when running webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## [Unreleased]
 
 ### Changed
+- Cloud build fixes where `npm run build` is run instead of `./node_modules/webpack/bin/webpack.js`
 - Change cron url from `tasks.cron` to match the correct path in `scripts`.
 - Add `web/core`to gitignore.
 - Add lines to sass-lint.

--- a/gcloud/cloudbuild_production.yaml
+++ b/gcloud/cloudbuild_production.yaml
@@ -56,7 +56,7 @@ steps:
   - |
     cd ./web/app/themes/THEMENAME
     npm install
-    ./node_modules/webpack/bin/webpack.js
+    npm run build
 
 # OPTIONAL DB SEED
 - name: gcr.io/cloud-builders/gsutil

--- a/gcloud/cloudbuild_stage.yaml
+++ b/gcloud/cloudbuild_stage.yaml
@@ -56,7 +56,7 @@ steps:
   - |
     cd ./web/app/themes/THEMENAME
     npm install
-    ./node_modules/webpack/bin/webpack.js
+    npm run build
 
 # OPTIONAL DB SEED
 - name: gcr.io/cloud-builders/gsutil


### PR DESCRIPTION
**CHANGED**

- Cloud build fixes where `npm run build` is run instead of `./node_modules/webpack/bin/webpack.js`