### PR TITLE
sass-lint and eslint configurations, some fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,9 @@ insert_final_newline = true
 max_line_length = 120
 tab_width = 4
 trim_trailing_whitespace = true
+
+[*.dust]
+max_line_length = 300
+
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+dist
+vendor
+node_modules

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -16,7 +16,10 @@
 # Linter VendorPrefix, option "identifier_list"
 
 files:
-  include: '**/*.scss'
+  include: './web/app/themes/**/assets/**/*.scss'
+  ignore:
+    - './web/wp/**/*.scss'
+    - './web/app/themes/**/node_modules/**/*.scss'
 options:
   formatter: stylish
   merge-default-rules: false
@@ -101,7 +104,7 @@ rules:
     - 2
     - additional-identifiers: []
       excluded-identifiers: []
-  placeholder-in-extend: 1
+  placeholder-in-extend: 0
   placeholder-name-format:
     - 2
     - convention: hyphenatedlowercase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Added package.json
 - Added lint script to composer
 - Added roave/security-advisories to composer dev-dependencies
+- Added `.eslintignore`
 
 ### Changed
 - Updated eslint config
 - object-cache: `redis-cache`
 - README.md improvements
 - Package updates, ready for Composer v2
+- Modified `.editorconfig` with dust and yaml specific changes
+- Modified `.sass-lint.yml` to allow [placeholder-in-extend](https://github.com/sasstools/sass-lint/blob/develop/docs/rules/placeholder-in-extend.md)
+- Modified `.sass-lint.yml` to include all `web/app/themes` asset folders
+- Modified `.sass-lint.yml` to ignore `node_modules` under `web/app/themes` and everything under `web/wp`
 
 ### Removed
 - object-cache: Removed redundant `wp-redis-object-cache-dropin` and `wp-redis-group-cache`


### PR DESCRIPTION
- Added `.eslintignore`
- Modified `.editorconfig` with dust and yaml specific changes
- Modified `.sass-lint.yml`
  - to allow [placeholder-in-extend](https://github.com/sasstools/sass-lint/blob/develop/docs/rules/placeholder-in-extend.md)
  - to include all `web/app/themes` asset folders
  - to ignore `node_modules` under `web/app/themes` and everything under `web/wp`