### PR TITLE
Added wp-geniem-project-bells-and-whistles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Added package.json
 - Added lint script to composer
 - Added roave/security-advisories to composer dev-dependencies
+- Added devgeniem/wp-geniem-project-bells-and-whistles (mu-plugin)
 
 ### Changed
 - Updated eslint config

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
     "devgeniem/wp-stateless-bucket-link-filter": "^1.0",
     "devgeniem/wp-cron-runner": "^1.0",
     "devgeniem/wp-disable-redis-object-cache-dropin": "^1.0",
-    "devgeniem/redis-cache": "^2.0"
+    "devgeniem/redis-cache": "^2.0",
+    "devgeniem/wp-geniem-project-bells-and-whistles": "^1.4"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "071920618692e96f1258df77a6395879",
+    "content-hash": "9ba033ea9c6501ed9754175c52697f53",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -658,6 +658,54 @@
                 "wordpress"
             ],
             "time": "2019-05-20T09:51:13+00:00"
+        },
+        {
+            "name": "devgeniem/wp-geniem-project-bells-and-whistles",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/devgeniem/wp-geniem-project-bells-and-whistles.git",
+                "reference": "656f5b938062082ff0835e55f6261f16509c4af6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/devgeniem/wp-geniem-project-bells-and-whistles/zipball/656f5b938062082ff0835e55f6261f16509c4af6",
+                "reference": "656f5b938062082ff0835e55f6261f16509c4af6",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": ">=v1.0.12",
+                "php": ">=7.1"
+            },
+            "type": "wordpress-muplugin",
+            "autoload": {
+                "psr-4": {
+                    "Geniem\\Project\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Ville Siltala",
+                    "email": "ville.siltala@geniem.com",
+                    "homepage": "https://github.com/villesiltala"
+                }
+            ],
+            "description": "Geniem WP Project Bells & Whistles",
+            "homepage": "http://geniem.com",
+            "keywords": [
+                "plugin",
+                "wordpress",
+                "wp"
+            ],
+            "support": {
+                "issues": "https://github.com/devgeniem/wp-geniem-project-bells-and-whistles/issues",
+                "source": "https://github.com/devgeniem/wp-geniem-project-bells-and-whistles/tree/1.4.0"
+            },
+            "time": "2020-02-13T13:14:51+00:00"
         },
         {
             "name": "devgeniem/wp-readonly-options",


### PR DESCRIPTION
Added [devgeniem/wp-geniem-project-bells-and-whistles](https://github.com/devgeniem/wp-geniem-project-bells-and-whistles) (mu-plugin)

> This WordPress mu-plugin is a collection of fixes and configurations for Geniem WordPress projects. A mu-plugin ensures that all functionalities get executed at an early stage of the WordPress bootstrap process and execution order can be controlled by using WordPress actions and filters.

Current available fixes:

- DisableAdminEmailVerification: Disable WordPress periodical admin email verification
- FixStreamDateFormat: Fix a date format bug in WP Stream database queries.
- Add404Headers: Remove no-cache headers from 404 error pages.
- CheckTasksCronFile: Verify there's a newline at the end of tasks.cron file.
