### PR TITLE
wp-stateless media mode to cdn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
-## [0.11.0] - 2019-11-19
+## [0.12.0] - 2021-02-01
 ### Changed
 - Changed `WP_STATELESS_MEDIA_MODE` to `cdn`. This helps to prevent sync, upload and performance problems with wp-stateless.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.11.0] - 2019-11-19
+### Changed
+- Changed `WP_STATELESS_MEDIA_MODE` to `cdn`. This helps to prevent sync, upload and performance problems with wp-stateless.
+
 ### Added
 - Added package.json
 - Added lint script to composer

--- a/config/application.php
+++ b/config/application.php
@@ -208,7 +208,7 @@ if ( file_exists( $env_config ) ) {
  * Setup WP Stateless to upload all the files into the Google Bucket.
  */
 define( 'WP_STATELESS_MEDIA_BUCKET', env( 'GOOGLE_CLOUD_STORAGE_BUCKET_NAME' ) );
-define( 'WP_STATELESS_MEDIA_MODE', 'stateless' );
+define( 'WP_STATELESS_MEDIA_MODE', 'cdn' );
 define( 'WP_STATELESS_MEDIA_BODY_REWRITE', 'false' );
 define( 'WP_STATELESS_MEDIA_SERVICE_ACCOUNT ', env( 'GOOGLE_SERVICE_ACCOUNT_EMAIL' ) );
 define( 'WP_STATELESS_MEDIA_JSON_KEY', env( 'GOOGLE_CLOUD_STORAGE_ACCESS_KEY' ) );


### PR DESCRIPTION
- Changed `WP_STATELESS_MEDIA_MODE` to `cdn`. This helps to prevent sync, upload and performance problems with wp-stateless.