### PR TITLE
Migrate to Xdebug 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## Changed
+- Updated environment variables and documentation for Xdebug 3.
+
 ## [0.13.0] - 2021-02-01
 ### Changed
 - Changed `WP_STATELESS_MEDIA_MODE` to `cdn`. This helps to prevent sync, upload and performance problems with wp-stateless.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ $ make init
 
 This starts the local development environment, installs packages using composer, builds project assets and seeds the database.
 
+## Debugging and profiling
+
+### Xdebug
+For debugging and profiling we use **Xdebug 3**. To enable Xdebug features, change its mode in compose file's environment variable `XDEBUG_MODE`.
+```
+XDEBUG_MODE: off
+```
+For different mode values see: https://xdebug.org/docs/all_settings#mode. Once enabled, remote debugging uses port `9003` by default.
+
+You can also define the IDE session key in `${XDEBUG_IDE_KEY}`. By default it is a generic value: `DEBUG`. Set it in your browser extension and editor configurations.
+```
+XDEBUG_IDE_KEY: DEBUG
+```
+
+For all environment variables for Xdebug, see the base image's [Dockerfile](https://github.com/devgeniem/ubuntu-docker-wordpress-development/blob/master/ubuntu-php-7.4/Dockerfile)
+
 ## Testing
 
 You can run the php codesniffer, rspec and sitespeed tests by using the Makefile:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,11 +69,16 @@ services:
       MYSQL_USER: wordpress
       MYSQL_PWD: wordpress
 
-      # Xdebug profiling is disabled because it slows down development
-      # If you want to profile this site turn it on and use ?XDEBUG_PROFILE get parameter or cookie
-      XDEBUG_ENABLE_PROFILE: 0
+      # Change the mode for Xdebug to enable it's features. Xdebug is off by default.
+      # For accepted values, see: https://xdebug.org/docs/all_settings#mode
+      XDEBUG_MODE: off
       # Connect to host machine for remote xdebug. The IP address is alias for host machine 127.0.0.1 by gdev
-      XDEBUG_REMOTE_HOST: 10.254.254.254
+      XDEBUG_CLIENT_HOST: 10.254.254.254
+      # This is the recommended default port.
+      XDEBUG_CLIENT_PORT: 9003
+      # Set the IDE session key to use in your editor.
+      # To use this default, set it in the browser extension and in your editor's debug configurations.
+      XDEBUG_IDE_KEY: DEBUG
 
       # Use same caching solution as in production
       NGINX_REDIS_CACHE_TTL_DEFAULT: 200 15m


### PR DESCRIPTION
Update Docker Composer configurations to work with the base image's new version using Xdebug 3.