### PR TITLE
Fixed basic auth env name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.13.2] - 2021-05-28
+- Fixed php74-stable image basic auth env name from `BASIC_AUTH_PASSWORD_HASH` to `BASIC_AUTH_PASSWORD`.
+
 ## [0.13.1] - 2021-02-08
 ### Fixed
 - Fixed image proxy to cache requests to container 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use this as a local development environment with our docker-image
 6. Update this Readme as many times as you can.
     * Most important details are usually the details about data models, and their input/output.
     * Also add all 3rd-party dependencies here
-7. Replace `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD_HASH` from `Dockerfile` with real credentials.
+7. Replace `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` from `Dockerfile` with real credentials.
     * You can find more info about formats here: http://nginx.org/en/docs/http/ngx_http_auth_basic_module.html
     * For example, you can generate password hash with: `$ openssl passwd -crypt "password"`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
       # These variables can be used in nginx templates like .htpasswd
       BASIC_AUTH_USER: hello
-      BASIC_AUTH_PASSWORD_HASH: world
+      BASIC_AUTH_PASSWORD: world
 
       # These will be mapped automatically in development to jwilder/nginx-proxy
       VIRTUAL_HOST: asiakas.test

--- a/nginx/environments/staging/server/.htpasswd.tmpl
+++ b/nginx/environments/staging/server/.htpasswd.tmpl
@@ -1,4 +1,4 @@
 ##
 # This file generates contents of .htpasswd
 ##
-${BASIC_AUTH_USER}:${BASIC_AUTH_PASSWORD_HASH}
+${BASIC_AUTH_USER}:${BASIC_AUTH_PASSWORD}

--- a/scripts/run-cron.sh
+++ b/scripts/run-cron.sh
@@ -6,8 +6,8 @@
 # If BASIC_AUTH_PASSWORD is set use basic authentication on curl.
 if [[ "${BASIC_AUTH_USER}" ]] && [[ "${BASIC_AUTH_PASSWORD}" ]]; then
 curl -u $BASIC_AUTH_USER:$BASIC_AUTH_PASSWORD $CRON_URL --insecure > /dev/null 2>&1
-elif [[ "${BASIC_AUTH_USER}" ]] && [[ "${BASIC_AUTH_PASSWORD_HASH}" ]]; then
-curl -u $BASIC_AUTH_USER:${BASIC_AUTH_PASSWORD_HASH/\{PLAIN\}/} $CRON_URL --insecure > /dev/null 2>&1
+elif [[ "${BASIC_AUTH_USER}" ]] && [[ "${BASIC_AUTH_PASSWORD}" ]]; then
+curl -u $BASIC_AUTH_USER:${BASIC_AUTH_PASSWORD/\{PLAIN\}/} $CRON_URL --insecure > /dev/null 2>&1
 else
 curl $CRON_URL --insecure > /dev/null 2>&1
 fi


### PR DESCRIPTION
- Fixed php74-stable image basic auth env name from `BASIC_AUTH_PASSWORD_HASH` to `BASIC_AUTH_PASSWORD`.